### PR TITLE
Expose action creators from createActionType

### DIFF
--- a/lib/createActionType.js
+++ b/lib/createActionType.js
@@ -14,6 +14,7 @@ function createActionType(actions) {
   Action.dispatch = function (x) {
     return dispatcher[x.type];
   };
+  Action.creators = actionCreators;
   t.mixin(Action, actionCreators);
   return Action;
 }


### PR DESCRIPTION
I think that naming it `creators` is just fine.

Fixes #14 
